### PR TITLE
refactor: extract rendering logic into dedicated HtmlRenderer class

### DIFF
--- a/WebFiori/Ui/HtmlRenderer.php
+++ b/WebFiori/Ui/HtmlRenderer.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace WebFiori\Ui;
+
+use WebFiori\Collections\Stack;
+
+/**
+ * A renderer that converts HTMLNode trees to HTML/XML strings.
+ *
+ * Unlike HTMLNode::toHTML(), this class keeps all rendering state local,
+ * making it safe for concurrent use in async contexts (Swoole, ReactPHP, etc.).
+ */
+class HtmlRenderer {
+    private bool $formatted;
+    private bool $quoted;
+    private bool $useForwardSlash;
+    private string $nl;
+    private string $tabSpace;
+    private int $tabCount;
+    private string $output;
+    private Stack $nodesStack;
+    /**
+     * Create a new renderer instance.
+     *
+     * @param bool $formatted Whether to produce indented, human-readable output.
+     * @param bool $quoted Whether to quote all attribute values.
+     * @param bool $useForwardSlash Whether void elements use self-closing slash.
+     */
+    public function __construct(bool $formatted = false, bool $quoted = false, bool $useForwardSlash = false) {
+        $this->formatted = $formatted;
+        $this->quoted = $quoted;
+        $this->useForwardSlash = $useForwardSlash;
+    }
+    /**
+     * Check if the renderer produces formatted output.
+     *
+     * @return bool True if formatted output is enabled.
+     */
+    public function isFormatted(): bool {
+        return $this->formatted;
+    }
+    /**
+     * Check if the renderer quotes attribute values.
+     *
+     * @return bool True if attribute quoting is enabled.
+     */
+    public function isQuoted(): bool {
+        return $this->quoted;
+    }
+    /**
+     * Check if void elements use self-closing forward slash.
+     *
+     * @return bool True if forward slash is enabled.
+     */
+    public function isUseForwardSlash(): bool {
+        return $this->useForwardSlash;
+    }
+    /**
+     * Render an HTMLNode tree to an HTML string.
+     *
+     * @param HTMLNode $node The root node to render.
+     * @param int $initTab Initial indentation level (only used when formatted).
+     *
+     * @return string The rendered HTML string.
+     */
+    public function render(HTMLNode $node, int $initTab = 0): string {
+        $this->output = '';
+        $this->nodesStack = new Stack();
+
+        if (!$this->formatted) {
+            $this->nl = '';
+            $this->tabSpace = '';
+            $this->tabCount = 0;
+        } else {
+            $this->nl = HTMLDoc::NL;
+            $this->tabCount = max(0, $initTab);
+            $this->tabSpace = str_repeat(' ', 4);
+        }
+
+        $this->pushNode($node);
+
+        return $this->output;
+    }
+    /**
+     * Render an HTMLNode tree to an XML string.
+     *
+     * @param HTMLNode $node The root node to render.
+     * @param bool $formatted Whether to format the output.
+     *
+     * @return string The rendered XML string with declaration.
+     */
+    public function renderXML(HTMLNode $node, bool $formatted = false): string {
+        $prevFormatted = $this->formatted;
+        $prevQuoted = $this->quoted;
+        $prevSlash = $this->useForwardSlash;
+
+        $this->formatted = $formatted;
+        $this->quoted = true;
+        $this->useForwardSlash = true;
+
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>';
+
+        if ($formatted) {
+            $xml .= HTMLDoc::NL;
+        }
+
+        $xml .= $this->render($node);
+
+        $this->formatted = $prevFormatted;
+        $this->quoted = $prevQuoted;
+        $this->useForwardSlash = $prevSlash;
+
+        return $xml;
+    }
+    /**
+     * Generate the opening tag for a node.
+     *
+     * @param HTMLNode $node The node to generate opening tag for.
+     *
+     * @return string The opening tag string.
+     */
+    private function openTag(HTMLNode $node): string {
+        $retVal = '<' . $node->getNodeName();
+
+        foreach ($node->getAttributes() as $attr => $val) {
+            if ($val === null) {
+                $retVal .= ' ' . $attr;
+            } else {
+                $valType = gettype($val);
+
+                if (!$this->quoted && ($valType == "integer" || $valType == 'double')) {
+                    $retVal .= ' ' . $attr . '=' . $val;
+                } else {
+                    if ($val != '' && !$this->quoted && strpos($val, '?') === false
+                            && strpos($val, '"') === false
+                            && strpos($val, ' ') === false
+                            && strpos($val, '/') === false
+                            && strpos($val, '-') === false) {
+                        $retVal .= ' ' . $attr . '=' . $val;
+                    } else {
+                        $retVal .= ' ' . $attr . '="' . str_replace(['&', '"'], ['&amp;', '&quot;'], $val) . '"';
+                    }
+                }
+            }
+        }
+
+        if ($node->isVoidNode() && $this->useForwardSlash) {
+            $retVal .= '/';
+        }
+        $retVal .= '>';
+
+        return $retVal;
+    }
+    /**
+     * Generate the closing tag for a node.
+     *
+     * @param HTMLNode $node The node to close.
+     *
+     * @return string The closing tag string.
+     */
+    private function closeTag(HTMLNode $node): string {
+        return '</' . $node->getNodeName() . '>';
+    }
+
+    private function pushNode(HTMLNode $node): void {
+        if ($node->isTextNode()) {
+            if (!$this->formatted) {
+                $this->output .= $node->getText();
+            } else {
+                $parent = $node->getParent();
+
+                if ($parent !== null) {
+                    $parentName = $parent->getNodeName();
+
+                    if ($parentName == 'code' || $parentName == 'pre' || $parentName == 'textarea') {
+                        $this->output .= $node->getText();
+                    } else {
+                        $this->output .= $this->getTab() . $node->getText() . $this->nl;
+                    }
+                } else {
+                    $this->output .= $this->getTab() . $node->getText() . $this->nl;
+                }
+            }
+        } else if ($node->isComment()) {
+            if (!$this->formatted) {
+                $this->output .= $node->getComment();
+            } else {
+                $this->output .= $this->getTab() . $node->getComment() . $this->nl;
+            }
+        } else if (!$node->isVoidNode()) {
+            $chCount = $node->children() !== null ? $node->children()->size() : 0;
+            $this->nodesStack->push($node);
+
+            if (!$this->formatted) {
+                $this->output .= $this->openTag($node);
+            } else {
+                $nodeType = $node->getNodeName();
+
+                if ($nodeType == 'pre' || $nodeType == 'textarea' || $nodeType == 'code') {
+                    $this->output .= $this->getTab() . $this->openTag($node);
+                } else {
+                    $this->output .= $this->getTab() . $this->openTag($node) . $this->nl;
+                }
+            }
+            $this->tabCount++;
+
+            for ($x = 0; $x < $chCount; $x++) {
+                $this->pushNode($node->children()->get($x));
+            }
+            $this->tabCount = max(0, $this->tabCount - 1);
+            $this->popNode();
+        } else {
+            if (!$this->formatted) {
+                $this->output .= $this->openTag($node);
+            } else {
+                $this->output .= $this->getTab() . $this->openTag($node) . $this->nl;
+            }
+        }
+    }
+
+    private function popNode(): void {
+        $node = $this->nodesStack->pop();
+
+        if ($node != null && !$this->formatted) {
+            $this->output .= $this->closeTag($node);
+        } else if ($node != null) {
+            $nodeType = $node->getNodeName();
+
+            if ($nodeType == 'pre' || $nodeType == 'textarea' || $nodeType == 'code') {
+                $this->output .= $this->closeTag($node) . $this->nl;
+            } else {
+                $this->output .= $this->getTab() . $this->closeTag($node) . $this->nl;
+            }
+        }
+    }
+
+    private function getTab(): string {
+        if ($this->tabCount == 0) {
+            return '';
+        }
+
+        return str_repeat($this->tabSpace, $this->tabCount);
+    }
+}

--- a/tests/WebFiori/Tests/Ui/HtmlRendererTest.php
+++ b/tests/WebFiori/Tests/Ui/HtmlRendererTest.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace WebFiori\Tests\Ui;
+
+use PHPUnit\Framework\TestCase;
+use WebFiori\Ui\HTMLDoc;
+use WebFiori\Ui\HTMLNode;
+use WebFiori\Ui\HtmlRenderer;
+
+class HtmlRendererTest extends TestCase {
+    /**
+     * @test
+     */
+    public function testConstructorDefaults() {
+        $renderer = new HtmlRenderer();
+        $this->assertFalse($renderer->isFormatted());
+        $this->assertFalse($renderer->isQuoted());
+        $this->assertFalse($renderer->isUseForwardSlash());
+    }
+    /**
+     * @test
+     */
+    public function testConstructorWithOptions() {
+        $renderer = new HtmlRenderer(formatted: true, quoted: true, useForwardSlash: true);
+        $this->assertTrue($renderer->isFormatted());
+        $this->assertTrue($renderer->isQuoted());
+        $this->assertTrue($renderer->isUseForwardSlash());
+    }
+    /**
+     * @test
+     */
+    public function testRenderSimpleElement() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('div');
+        $this->assertEquals('<div></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderWithAttributes() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('div', ['id' => 'main', 'class' => 'container']);
+        $this->assertEquals('<div id=main class=container></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderQuotedAttributes() {
+        $renderer = new HtmlRenderer(quoted: true);
+        $node = new HTMLNode('div', ['id' => 'main']);
+        $this->assertEquals('<div id="main"></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderVoidElement() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('br');
+        $this->assertEquals('<br>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderVoidElementWithForwardSlash() {
+        $renderer = new HtmlRenderer(useForwardSlash: true);
+        $node = new HTMLNode('br');
+        $this->assertEquals('<br/>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderTextNode() {
+        $renderer = new HtmlRenderer();
+        $node = HTMLNode::createTextNode('Hello World');
+        $this->assertEquals('Hello World', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderCommentNode() {
+        $renderer = new HtmlRenderer();
+        $node = HTMLNode::createComment('This is a comment');
+        $this->assertEquals('<!--This is a comment-->', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderNestedElements() {
+        $renderer = new HtmlRenderer();
+        $div = new HTMLNode('div');
+        $div->addChild('p')->text('Hello');
+        $div->addChild('span')->text('World');
+        $this->assertEquals('<div><p>Hello</p><span>World</span></div>', $renderer->render($div));
+    }
+    /**
+     * @test
+     */
+    public function testRenderFormatted() {
+        $renderer = new HtmlRenderer(formatted: true);
+        $div = new HTMLNode('div');
+        $div->addChild('p')->text('Hello');
+
+        $expected = '<div>' . HTMLDoc::NL
+            . '    <p>' . HTMLDoc::NL
+            . '        Hello' . HTMLDoc::NL
+            . '    </p>' . HTMLDoc::NL
+            . '</div>' . HTMLDoc::NL;
+
+        $this->assertEquals($expected, $renderer->render($div));
+    }
+    /**
+     * @test
+     */
+    public function testRenderFormattedWithInitTab() {
+        $renderer = new HtmlRenderer(formatted: true);
+        $node = new HTMLNode('p');
+        $node->text('Content');
+
+        $expected = '    <p>' . HTMLDoc::NL
+            . '        Content' . HTMLDoc::NL
+            . '    </p>' . HTMLDoc::NL;
+
+        $this->assertEquals($expected, $renderer->render($node, 1));
+    }
+    /**
+     * @test
+     */
+    public function testRenderFormattedPreservesPreContent() {
+        $renderer = new HtmlRenderer(formatted: true);
+        $pre = new HTMLNode('pre');
+        $pre->text("line1\r\nline2");
+
+        $result = $renderer->render($pre);
+        $this->assertStringContainsString('<pre>', $result);
+        $this->assertStringContainsString("line1\r\nline2", $result);
+    }
+    /**
+     * @test
+     */
+    public function testRenderXML() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('root');
+        $node->addChild('item', ['id' => 'one'])->text('Value');
+
+        $expected = '<?xml version="1.0" encoding="UTF-8"?><root><item id="one">Value</item></root>';
+        $this->assertEquals($expected, $renderer->renderXML($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderXMLFormatted() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('root');
+        $node->addChild('item')->text('Val');
+
+        $result = $renderer->renderXML($node, true);
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"?>' . HTMLDoc::NL, $result);
+        $this->assertStringContainsString('    <item>', $result);
+    }
+    /**
+     * @test
+     */
+    public function testRenderXMLVoidWithSlash() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('root');
+        $node->addChild('br');
+
+        $result = $renderer->renderXML($node);
+        $this->assertStringContainsString('<br/>', $result);
+    }
+    /**
+     * @test
+     */
+    public function testNoSharedStateBetweenRenderers() {
+        $node = new HTMLNode('div', ['data-x' => 'val']);
+
+        $unquoted = new HtmlRenderer(quoted: false);
+        $quoted = new HtmlRenderer(quoted: true);
+
+        $this->assertEquals('<div data-x=val></div>', $unquoted->render($node));
+        $this->assertEquals('<div data-x="val"></div>', $quoted->render($node));
+        // Rendering with quoted didn't affect unquoted
+        $this->assertEquals('<div data-x=val></div>', $unquoted->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testNoSharedStateBetweenRenders() {
+        $renderer = new HtmlRenderer(formatted: true);
+
+        $node1 = new HTMLNode('div');
+        $node1->addChild('p')->text('First');
+
+        $node2 = new HTMLNode('span');
+        $node2->text('Second');
+
+        // Render twice - state should reset each time
+        $result1 = $renderer->render($node1);
+        $result2 = $renderer->render($node2);
+
+        $this->assertStringStartsWith('<div>', $result1);
+        $this->assertStringStartsWith('<span>', $result2);
+    }
+    /**
+     * @test
+     */
+    public function testRenderAttributeWithAmpersand() {
+        $renderer = new HtmlRenderer(quoted: true);
+        $node = new HTMLNode('a', ['href' => '/search?a=1&b=2']);
+        $this->assertEquals('<a href="/search?a=1&amp;b=2"></a>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderAttributeWithQuotes() {
+        $renderer = new HtmlRenderer(quoted: true);
+        $node = new HTMLNode('div', ['title' => 'He said "hi"']);
+        $this->assertEquals('<div title="He said &quot;hi&quot;"></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderIntegerAttribute() {
+        $renderer = new HtmlRenderer(quoted: false);
+        $node = new HTMLNode('div');
+        $node->setAttribute('tabindex', 5);
+        $this->assertEquals('<div tabindex=5></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderIntegerAttributeQuoted() {
+        $renderer = new HtmlRenderer(quoted: true);
+        $node = new HTMLNode('div');
+        $node->setAttribute('tabindex', 5);
+        $this->assertEquals('<div tabindex="5"></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderDoubleAttributeQuoted() {
+        $renderer = new HtmlRenderer(quoted: true);
+        $node = new HTMLNode('div');
+        $node->setAttribute('data-val', 3.14);
+        $this->assertEquals('<div data-val="3.14"></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderBooleanAttribute() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('div');
+        $node->setAttribute('hidden', null);
+        $this->assertEquals('<div hidden></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderDeeplyNested() {
+        $renderer = new HtmlRenderer();
+        $root = new HTMLNode('div');
+        $level1 = $root->addChild('section');
+        $level2 = $level1->addChild('article');
+        $level2->addChild('p')->text('Deep');
+
+        $this->assertEquals(
+            '<div><section><article><p>Deep</p></article></section></div>',
+            $renderer->render($root)
+        );
+    }
+    /**
+     * @test
+     */
+    public function testRenderMatchesToHTML() {
+        $node = new HTMLNode('div', ['class' => 'wrapper']);
+        $node->addChild('h1')->text('Title');
+        $ul = $node->addChild('ul');
+        $ul->li('Item 1');
+        $ul->li('Item 2');
+        $node->addChild('br');
+
+        $renderer = new HtmlRenderer();
+        $this->assertEquals($node->toHTML(false), $renderer->render($node));
+
+        $rendererFmt = new HtmlRenderer(formatted: true);
+        $this->assertEquals($node->toHTML(true), $rendererFmt->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderXMLMatchesToXML() {
+        $node = new HTMLNode('root');
+        $node->addChild('child', ['attr' => 'val'])->text('content');
+        $node->addChild('empty')->setIsVoidNode(true);
+
+        $renderer = new HtmlRenderer();
+        $this->assertEquals($node->toXML(false), $renderer->renderXML($node));
+        $this->assertEquals($node->toXML(true), $renderer->renderXML($node, true));
+    }
+    /**
+     * @test
+     */
+    public function testRenderEmptyElement() {
+        $renderer = new HtmlRenderer();
+        $node = new HTMLNode('div');
+        $this->assertEquals('<div></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderFormattedComment() {
+        $renderer = new HtmlRenderer(formatted: true);
+        $div = new HTMLNode('div');
+        $div->addChild(HTMLNode::createComment('A comment'));
+        $div->addChild('p')->text('After');
+
+        $result = $renderer->render($div);
+        $this->assertStringContainsString('<!--A comment-->', $result);
+        $this->assertStringContainsString('<p>', $result);
+    }
+    /**
+     * @test
+     */
+    public function testRenderXMLDoesNotMutateRendererState() {
+        $renderer = new HtmlRenderer(formatted: false, quoted: false, useForwardSlash: false);
+        $node = new HTMLNode('div', ['x' => 'y']);
+
+        // renderXML internally sets quoted=true, slash=true
+        $renderer->renderXML($node);
+
+        // After renderXML, renderer should still be unquoted, no slash
+        $this->assertFalse($renderer->isQuoted());
+        $this->assertFalse($renderer->isUseForwardSlash());
+        $this->assertEquals('<div x=y></div>', $renderer->render($node));
+    }
+    /**
+     * @test
+     */
+    public function testRenderTextNodeWithoutParentFormatted() {
+        $renderer = new HtmlRenderer(formatted: true);
+        $node = HTMLNode::createTextNode('Orphan text');
+        $result = $renderer->render($node);
+        $this->assertStringContainsString('Orphan text', $result);
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -21,6 +21,7 @@
       <file>../WebFiori/Ui/Input.php</file>
       <file>../WebFiori/Ui/HTMLTable.php</file>
       <file>../WebFiori/Ui/TemplateCompiler.php</file>
+      <file>../WebFiori/Ui/HtmlRenderer.php</file>
     </include>
   </source>
 </phpunit>


### PR DESCRIPTION
# Summary
Extract HTML/XML rendering from HTMLNode into a standalone `HtmlRenderer` class with per-instance configuration and no shared mutable state.

## Motivation
HTMLNode uses static variables (`$IsFormatted`, `$IsQuoted`, `$UseForwardSlash`) as global state shared across all instances. Calling `setIsQuotedAttribute(true)` on any node changes behavior for every other node. This is unsafe in async contexts. Fixes #64 and #61.

## Changes
- New `WebFiori\Ui\HtmlRenderer` class with local rendering state
- `render(HTMLNode $node, int $initTab = 0): string` — produces HTML
- `renderXML(HTMLNode $node, bool $formatted = false): string` — produces XML
- Constructor accepts `formatted`, `quoted`, `useForwardSlash` options
- Existing `toHTML()`/`toXML()` on HTMLNode remain unchanged (backward compatible)
- 31 tests with 100% line and method coverage

## How to Test / Verify
```bash
cd tests && php ../vendor/bin/phpunit WebFiori/Tests/Ui/HtmlRendererTest.php
```
31 tests, 45 assertions, 100% coverage. Full suite: 352 tests pass.

## Breaking Changes and Migration Steps
None. This is additive — `HtmlRenderer` is a new class. Existing API is untouched.

## Checklist
- [x] I reviewed my own diff before requesting review
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I added/updated tests (or explained why not) — 100% coverage
- [x] I updated docs (if needed) [Docs Repo](https://github.com/WebFiori/docs) — N/A, new class with PHPDoc
- [x] I ran lint/cs-fixer (if applicable) (`composer fix-cs`)
- [x] I considered backward compatibility
- [x] I considered security

## Related issues
Closes #64, Closes #61